### PR TITLE
Rename contributors to authors

### DIFF
--- a/app/assets/stylesheets/avatars.scss
+++ b/app/assets/stylesheets/avatars.scss
@@ -1,29 +1,29 @@
 img.avatar {
-  
+
   $avatar-default-size: 48px;
-  
+
   width: $avatar-default-size;
   height: $avatar-default-size;
   margin: 5px;
   opacity: 0.5;
-  
+
   &.toolbar {
     width: 18px;
     height: 18px;
     margin: -2px 0px 0px 0px;
   }
-  
+
   &.small {
     width: ($avatar-default-size / 2);
     height: ($avatar-default-size / 2);
   }
-  
+
   &.large {
     width: ($avatar-default-size * 2);
     height: ($avatar-default-size * 2);
   }
-  
-  &.contributor {
+
+  &.author {
     opacity: 1.0;
   }
 

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -16,7 +16,7 @@ class ProposalsController < ApplicationController
   def show
     @is_author = current_user == @proposal.proposer
     # Can the current user vote?
-    @can_vote = current_user.try(:contributor) && !@is_author
+    @can_vote = current_user.try(:author) && !@is_author
     # Get activity list
     presenter = ProposalPresenter.new(@proposal)
     @activity = presenter.activity_log

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,8 +8,8 @@ class UsersController < ApplicationController
   before_action :authorise, only: [:edit, :update]
 
   def index
-    @contributors = User.where(contributor: true)
-    @others = User.where(contributor: false)
+    @authors = User.where(author: true)
+    @others = User.where(author: false)
   end
 
   def show

--- a/app/models/concerns/votable.rb
+++ b/app/models/concerns/votable.rb
@@ -62,9 +62,9 @@ module Votable
     def count_vote_in_comment(comment, time_of_last_commit)
       # Skip instructions
       return if Regexp.new(INSTRUCTION_HEADER).match?(comment.body)
-      # Ignore proposer and non-contributors
+      # Ignore proposer and non-authors
       user = User.find_or_create_by!(login: comment.user.login)
-      return if user == proposer || !user.contributor
+      return if user == proposer || !user.author
       # Store vote in an interaction record
       interaction = interactions.find_or_create_by!(user: user)
       interaction.set_last_vote_from_comment!(comment, time_of_last_commit)

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -62,7 +62,7 @@ class Proposal < ApplicationRecord
   end
 
   def close!
-    proposer.update_github_contributor_status && proposer.save!
+    proposer.update_author_status_from_github && proposer.save!
     update_state!
   end
 
@@ -72,7 +72,7 @@ class Proposal < ApplicationRecord
 
   def notify_voters
     # Notify users that there is a new proposal to vote on
-    User.where.not(email: nil).where(notify_new: true, contributor: true).all.find_each do |user|
+    User.where.not(email: nil).where(notify_new: true, author: true).all.find_each do |user|
       ProposalsMailer.new_proposal(user, self).deliver_later unless user == proposer
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User < ApplicationRecord
     github_user = Octokit.user(login)
     self.avatar_url = github_user.avatar_url
     self.email ||= github_user.email
-    self.contributor = update_github_contributor_status
+    self.author = update_author_status_from_github
     nil # to avoid halting validation chain until 5.1
   rescue Octokit::NotFound
     # TODO Need to do something here if the user has been deleted,
@@ -57,10 +57,10 @@ class User < ApplicationRecord
     nil
   end
 
-  def update_github_contributor_status
+  def update_author_status_from_github
     # TODO fix autopagination not working here: https://github.com/openpolitics/groupthink/issues/176
-    @contributors ||= Octokit.contributors(ENV.fetch("GITHUB_REPO"), per_page: 100)
-    self.contributor = !@contributors.find { |x| x.login == login }.nil?
+    @authors ||= Octokit.contributors(ENV.fetch("GITHUB_REPO"), per_page: 100)
+    self.author = !@authors.find { |x| x.login == login }.nil?
   end
 
   def vote(proposal)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,7 @@
             <ul class="nav navbar-nav">
               <li><%= link_to "Proposals", proposals_path %></li>
               <li><%= link_to "Ideas", ideas_path %></li>
-              <li><%= link_to "Contributors", users_path %></li>
+              <li><%= link_to "People", users_path %></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
               <% if signed_in? %>

--- a/app/views/shared/_person.html.erb
+++ b/app/views/shared/_person.html.erb
@@ -1,4 +1,4 @@
 <a href='/users/<%= person.login %>'><img src='<%= person.avatar_url %>'
 alt='<%= person.login %>'
 title='<%= person.login %>'
-class="img-rounded avatar <%= size rescue nil %> <%= "contributor" if person.contributor %>" /></a>
+class="img-rounded avatar <%= size rescue nil %> <%= "author" if person.author %>" /></a>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,15 +2,15 @@
 
 Click on a user image to see their activity history.
 
-<h2>Contributors (<%= @contributors.count %>)</h2>
+<h2>Authors (<%= @authors.count %>)</h2>
 
 <p>
-  Contributors have had a proposal accepted, and thus under the rules, get voting
+  Authors have had a proposal accepted, and thus under the rules, get voting
   rights on future proposals.
 </p>
 
 <div class='userlist'>
-  <% @contributors.each do |user| %>
+  <% @authors.each do |user| %>
     <%= render partial: 'shared/person', locals: {person: user } %>
   <% end %>
 </div>

--- a/app/views/users/index.json.erb
+++ b/app/views/users/index.json.erb
@@ -1,4 +1,4 @@
 {
   "count": <%= User.count %>,
-  "contributors": <%= @contributors.count %>
+  "authors": <%= @authors.count %>
 }

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,8 +5,8 @@
   <%= @user.login %> <a href='https://github.com/<%= @user.login %>'><%= fa_icon 'github' %></a>
 </h1>
 
-<% if @user.contributor %>
-  <div class='label label-primary'>contributor</div>
+<% if @user.author %>
+  <div class='label label-primary'>author</div>
 <% end %>
 
 <h2 style='clear: right'>Not voted on yet:</h2>
@@ -30,9 +30,9 @@
           <span class='hidden-xs'><%= pr.state.capitalize %></span>
         </span>
       </td>
-      <td><a href='/proposals/<%= pr.number %>'><%= pr.title %></a></td> 
-      <td class="text-center"><%= vote_icon(@user.vote(pr)) %></td> 
-      <td class="proposer text-center"><%= render partial: 'shared/person', locals: {person: pr.proposer, size: "small" } %></td> 
+      <td><a href='/proposals/<%= pr.number %>'><%= pr.title %></a></td>
+      <td class="text-center"><%= vote_icon(@user.vote(pr)) %></td>
+      <td class="proposer text-center"><%= render partial: 'shared/person', locals: {person: pr.proposer, size: "small" } %></td>
     </tr>
   <% end %>
 </table>

--- a/db/migrate/20190906211203_rename_contributors_to_authors.rb
+++ b/db/migrate/20190906211203_rename_contributors_to_authors.rb
@@ -1,0 +1,5 @@
+class RenameContributorsToAuthors < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :users, :contributor, :author
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,48 +1,48 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160727211441) do
+ActiveRecord::Schema.define(version: 2019_09_06_211203) do
+
   create_table "interactions", force: :cascade do |t|
-    t.integer  "user_id",     null: false
-    t.integer  "proposal_id", null: false
-    t.string   "last_vote"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer "user_id", null: false
+    t.integer "proposal_id", null: false
+    t.string "last_vote"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["proposal_id"], name: "index_interactions_on_proposal_id"
     t.index ["user_id"], name: "index_interactions_on_user_id"
   end
 
   create_table "proposals", force: :cascade do |t|
-    t.integer  "number",      null: false
-    t.string   "state",       null: false
-    t.string   "title",       null: false
-    t.integer  "proposer_id", null: false
-    t.datetime "opened_at",   null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer "number", null: false
+    t.string "state", null: false
+    t.string "title", null: false
+    t.integer "proposer_id", null: false
+    t.datetime "opened_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["proposer_id"], name: "index_proposals_on_proposer_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "login",                       null: false
-    t.string   "avatar_url"
-    t.boolean  "contributor", default: false, null: false
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.string   "email"
-    t.string   "provider"
-    t.string   "uid"
-    t.boolean  "notify_new",  default: true
+    t.string "login", null: false
+    t.string "avatar_url"
+    t.boolean "author", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "email"
+    t.string "provider"
+    t.string "uid"
+    t.boolean "notify_new", default: true
   end
+
 end

--- a/lib/tasks/update.rake
+++ b/lib/tasks/update.rake
@@ -15,16 +15,16 @@ def update_users!
   User.all.each do |user|
     Rails.logger.info " - #{user.login}"
     user.load_from_github
-    Rails.logger.info "     has become a contributor" if user.contributor_changed?
+    Rails.logger.info "     has become an author" if user.author_changed?
     user.save! if user.changed?
   end
-  Rails.logger.info "Updating new contributors from GitHub"
-  Octokit.contributors(ENV.fetch("GITHUB_REPO")).each do |contributor|
-    params = { login: contributor["login"] }
+  Rails.logger.info "Updating new authors from GitHub"
+  Octokit.contributors(ENV.fetch("GITHUB_REPO")).each do |author|
+    params = { login: author["login"] }
     unless User.find_by(params)
-      Rails.logger.info " - #{contributor["login"]}"
+      Rails.logger.info " - #{author["login"]}"
       user = User.create!(params)
-      user.contributor = true
+      user.author = true
       user.save!
     end
   end

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe ProposalsController, type: :controller do
   render_views
 
-  let(:proposer) { create :user, contributor: true, notify_new: true }
+  let(:proposer) { create :user, author: true, notify_new: true }
   let!(:proposal) { create :proposal, proposer: proposer }
 
   around do |example|

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe UsersController, type: :controller do
   render_views
 
-  let!(:user) { create :user, contributor: true, notify_new: true }
+  let!(:user) { create :user, author: true, notify_new: true }
 
   around do |example|
     env = {
@@ -27,8 +27,8 @@ RSpec.describe UsersController, type: :controller do
       expect(response).to be_ok
     end
 
-    it "includes contributor list" do
-      expect(response.body).to include "Contributors"
+    it "includes author list" do
+      expect(response.body).to include "Authors"
     end
 
     it "includes current user" do

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :user do
     login { Faker::Internet.user_name }
-    contributor { true }
+    author { true }
     email { Faker::Internet.email }
     avatar_url { Faker::Internet.url }
     provider { "github" }

--- a/spec/mailers/proposals_mailer_spec.rb
+++ b/spec/mailers/proposals_mailer_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe ProposalsMailer, type: :mailer do
 
   describe "new_proposal" do
     let(:proposer) { FactoryBot.create :user }
-    let(:contributor) { FactoryBot.create :user, email: "contributor@mydomain.com" }
-    let(:proposal) { FactoryBot.create :proposal, proposer: contributor }
-    let(:mail) { described_class.new_proposal(contributor, proposal) }
+    let(:author) { FactoryBot.create :user, email: "author@mydomain.com" }
+    let(:proposal) { FactoryBot.create :proposal, proposer: author }
+    let(:mail) { described_class.new_proposal(author, proposal) }
 
     it "sends email to right person" do
-      expect(mail.to).to eq(["contributor@mydomain.com"])
+      expect(mail.to).to eq(["author@mydomain.com"])
     end
 
     it "sends email from specified domain" do
@@ -36,7 +36,7 @@ RSpec.describe ProposalsMailer, type: :mailer do
     end
 
     it "includes link to edit settings for user" do
-      expect(mail.body.encoded).to match(/http.*\/users\/#{contributor.login}\/edit/)
+      expect(mail.body.encoded).to match(/http.*\/users\/#{author.login}\/edit/)
     end
   end
 end

--- a/spec/models/concerns/votable_spec.rb
+++ b/spec/models/concerns/votable_spec.rb
@@ -13,8 +13,8 @@ def mock_vote(vote: "✅", created_at: 1.hour.ago, login: "test")
 end
 
 RSpec.describe Votable, type: :model do
-  let(:voter1) { create :user, contributor: true, notify_new: false }
-  let(:voter2) { create :user, contributor: true, notify_new: false }
+  let(:voter1) { create :user, author: true, notify_new: false }
+  let(:voter2) { create :user, author: true, notify_new: false }
 
   let!(:pr) { create :proposal }
 
@@ -150,10 +150,10 @@ RSpec.describe Votable, type: :model do
         .with(/<!-- votebot instructions -->/)
     end
 
-    it "contains a link to the contributor list" do
+    it "contains a link to the author list" do
       pr.__send__(:post_instructions)
       expect(pr).to have_received(:github_add_comment)
-        .with(/\[contributor\]\(http:\/\/example.com\/users\/\)/)
+        .with(/\[.*?\]\(http:\/\/example.com\/users\/\)/)
     end
 
     it "contains voting table with info on yes votes" do

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -77,10 +77,10 @@ RSpec.describe Proposal, type: :model do
   end
 
   context "with notification of new proposals" do
-    let!(:proposer) { create :user, contributor: true, notify_new: true }
-    let!(:voter) { create :user, contributor: true, notify_new: true }
-    let!(:no_notifications) { create :user, contributor: true, notify_new: false }
-    let!(:participant) { create :user, contributor: false, notify_new: true }
+    let!(:proposer) { create :user, author: true, notify_new: true }
+    let!(:voter) { create :user, author: true, notify_new: true }
+    let!(:no_notifications) { create :user, author: true, notify_new: false }
+    let!(:participant) { create :user, author: false, notify_new: true }
     let!(:mail) { instance_double("mail") }
 
     before do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe User, type: :model do
       expect(u.email).to eq "test@example.com"
     end
 
-    it "sets contributor state" do
-      expect(u.contributor).to eq true
+    it "sets author state" do
+      expect(u.author).to eq true
     end
   end
 end


### PR DESCRIPTION
In preparation for splitting out contribution status and voter status, it makes sense to call contributors what they are actually - authors. Anyone who gets involved is a contributor, so author is a more precise and correct term.