### PR TITLE
Split voter and author state - part 1

### DIFF
--- a/app/assets/stylesheets/avatars.scss
+++ b/app/assets/stylesheets/avatars.scss
@@ -27,4 +27,8 @@ img.avatar {
     opacity: 1.0;
   }
 
+  &.voter {
+    box-shadow: 0px 0px 2px 2px lightgray;
+  }
+
 }

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -16,7 +16,7 @@ class ProposalsController < ApplicationController
   def show
     @is_author = current_user == @proposal.proposer
     # Can the current user vote?
-    @can_vote = current_user.try(:author) && !@is_author
+    @can_vote = current_user.try(:voter) && !@is_author
     # Get activity list
     presenter = ProposalPresenter.new(@proposal)
     @activity = presenter.activity_log

--- a/app/models/concerns/votable.rb
+++ b/app/models/concerns/votable.rb
@@ -62,9 +62,9 @@ module Votable
     def count_vote_in_comment(comment, time_of_last_commit)
       # Skip instructions
       return if Regexp.new(INSTRUCTION_HEADER).match?(comment.body)
-      # Ignore proposer and non-authors
+      # Ignore proposer and non-voters
       user = User.find_or_create_by!(login: comment.user.login)
-      return if user == proposer || !user.author
+      return if user == proposer || !user.voter
       # Store vote in an interaction record
       interaction = interactions.find_or_create_by!(user: user)
       interaction.set_last_vote_from_comment!(comment, time_of_last_commit)

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -72,8 +72,8 @@ class Proposal < ApplicationRecord
 
   def notify_voters
     # Notify users that there is a new proposal to vote on
-    User.where.not(email: nil).where(notify_new: true, author: true).all.find_each do |user|
-      ProposalsMailer.new_proposal(user, self).deliver_later unless user == proposer
+    User.where.not(email: nil).where(notify_new: true).all.find_each do |user|
+      ProposalsMailer.new_proposal(user, self).deliver_later if user.voter && user != proposer
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,6 +63,11 @@ class User < ApplicationRecord
     self.author = !@authors.find { |x| x.login == login }.nil?
   end
 
+  def voter
+    # For now, authors are voters - this will be expanded upon
+    author
+  end
+
   def vote(proposal)
     interactions.find_by(proposal: proposal).try(:state)
   end

--- a/app/views/proposals_mailer/new_proposal.html.erb
+++ b/app/views/proposals_mailer/new_proposal.html.erb
@@ -1,8 +1,8 @@
 Hi,
 
 <p>
-  A new proposal has been submitted to the OpenPolitics Manifesto, and as a
-  previous contributor you can vote on whether or not it's accepted.
+  A new proposal has been submitted to the OpenPolitics Manifesto, and
+  you can vote on whether or not it's accepted.
 </p>
 
 <h2>

--- a/app/views/proposals_mailer/new_proposal.text.erb
+++ b/app/views/proposals_mailer/new_proposal.text.erb
@@ -1,7 +1,7 @@
 Hi,
 
-A new proposal has been submitted to the OpenPolitics Manifesto, and as a
-previous contributor you can vote on whether or not it's accepted.
+A new proposal has been submitted to the OpenPolitics Manifesto, and
+you can vote on whether or not it's accepted.
 
 <%= @proposal.title %>: <%= url_for(@proposal) %>
 

--- a/app/views/shared/_person.html.erb
+++ b/app/views/shared/_person.html.erb
@@ -1,4 +1,4 @@
 <a href='/users/<%= person.login %>'><img src='<%= person.avatar_url %>'
 alt='<%= person.login %>'
 title='<%= person.login %>'
-class="img-rounded avatar <%= size rescue nil %> <%= "author" if person.author %>" /></a>
+class="img-rounded avatar <%= size rescue nil %> <%= "author" if person.author %> <%= "voter" if person.voter %>" /></a>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,7 +2,7 @@
 
 Click on a user image to see their activity history.
 
-<h2>Authors (<%= @authors.count %>)</h2>
+<h2>Authors & Voters (<%= @authors.count %>)</h2>
 
 <p>
   Authors have had a proposal accepted, and thus under the rules, get voting

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -15,10 +15,10 @@ Click on a user image to see their activity history.
   <% end %>
 </div>
 
-<h2>Other participants (<%= @others.count %>)</h2>
+<h2>Other contributors (<%= @others.count %>)</h2>
 
 <p>
-  Other participants have either submitted a (so far) unsuccessful proposal, or just taken
+  Other contributors have either submitted a (so far) unsuccessful proposal, or just taken
   part in the discussion, and do not yet have voting rights.
 </p>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,6 +9,10 @@
   <div class='label label-primary'>author</div>
 <% end %>
 
+<% if @user.voter %>
+  <div class='label label-primary'>voter</div>
+<% end %>
+
 <h2 style='clear: right'>Not voted on yet:</h2>
 
 <%= render partial: 'shared/proposal_list', locals: {proposals: @not_voted} %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,7 @@ en:
     success: Your change will now go into a queue to be reviewed before it's merged in. If you'd like to look at the queue, and see the votes and comments on your submission, press the "View all proposals" button.
     resubmit: "Closed automatically: maximum age exceeded. Please feel free to resubmit this as a new proposal, but remember you will need to base any new proposal on the current policy text."
     instruction_comment: |
-      This proposal is open for discussion and voting. If you are a [contributor](%{site_url}/users/) to this repository (and not the proposer), you may vote on whether or not it is accepted.
+      This proposal is open for discussion and voting. If you are an [eligible voter](%{site_url}/users/) on this project (and not the proposer), you may cast your vote on whether or not it is accepted.
 
       ## How to vote
       Vote by entering one of the following symbols in a comment on this pull request. Only your last vote will be counted, and you may change your vote at any time until the change is accepted or closed.

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe UsersController, type: :controller do
       expect(response.body).to include "Authors"
     end
 
+    it "includes voter list" do
+      expect(response.body).to include "Voters"
+    end
+
     it "includes current user" do
       expect(response.body).to include user.login
     end

--- a/spec/mailers/proposals_mailer_spec.rb
+++ b/spec/mailers/proposals_mailer_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe ProposalsMailer, type: :mailer do
 
   describe "new_proposal" do
     let(:proposer) { FactoryBot.create :user }
-    let(:author) { FactoryBot.create :user, email: "author@mydomain.com" }
-    let(:proposal) { FactoryBot.create :proposal, proposer: author }
-    let(:mail) { described_class.new_proposal(author, proposal) }
+    let(:voter) { FactoryBot.create :user, email: "voter@mydomain.com" }
+    let(:proposal) { FactoryBot.create :proposal, proposer: voter }
+    let(:mail) { described_class.new_proposal(voter, proposal) }
 
     it "sends email to right person" do
-      expect(mail.to).to eq(["author@mydomain.com"])
+      expect(mail.to).to eq(["voter@mydomain.com"])
     end
 
     it "sends email from specified domain" do
@@ -36,7 +36,7 @@ RSpec.describe ProposalsMailer, type: :mailer do
     end
 
     it "includes link to edit settings for user" do
-      expect(mail.body.encoded).to match(/http.*\/users\/#{author.login}\/edit/)
+      expect(mail.body.encoded).to match(/http.*\/users\/#{voter.login}\/edit/)
     end
   end
 end


### PR DESCRIPTION
This PR splits authors and voters. This is just a cosmetic and code refactor with no new data or state - voters are still just authors, though the code paths are in place for a new voter state to be added separately.