### PR TITLE
Administration interface

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,6 +47,7 @@ Style/DocumentationMethod:
     - 'spec/**/*.rb'
     - 'app/mailers/proposals_mailer.rb'
     - 'app/presenters/proposal_presenter.rb'
+    - 'app/models/ability.rb'
     - 'app/models/proposal.rb'
     - 'app/models/interaction.rb'
     - 'app/models/concerns/votable.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem "bugsnag"
 gem "devise"
 gem "omniauth-github"
 gem "omniauth-rails_csrf_protection", "~> 0.1"
+gem "cancancan"
+gem "rails_admin"
 
 gem "font-awesome-rails"
 

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem "omniauth-github"
 gem "omniauth-rails_csrf_protection", "~> 0.1"
 gem "cancancan"
 gem "rails_admin"
+gem "paper_trail"
 
 gem "font-awesome-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (6.0.0)
       activesupport (= 6.0.0)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (6.0.0)
       activemodel (= 6.0.0)
       activesupport (= 6.0.0)
@@ -65,6 +69,7 @@ GEM
       concurrent-ruby (~> 1.0)
     builder (3.2.3)
     byebug (11.0.1)
+    cancancan (3.0.1)
     climate_control (0.2.0)
     coderay (1.1.2)
     coffee-rails (5.0.0)
@@ -166,6 +171,9 @@ GEM
     guard-rubocop (1.3.0)
       guard (~> 2.0)
       rubocop (~> 0.20)
+    haml (5.1.2)
+      temple (>= 0.8.0)
+      tilt
     hashdiff (1.0.0)
     hashie (3.6.0)
     htmlentities (4.3.4)
@@ -183,6 +191,8 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (6.0.1)
+      railties (>= 3.2.16)
     json (2.2.0)
     jwt (2.2.1)
     kaminari (1.1.1)
@@ -223,6 +233,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nenv (0.3.0)
+    nested_form (0.3.2)
     nio4r (2.5.1)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
@@ -261,6 +272,9 @@ GEM
     puma (4.1.0)
       nio4r (~> 2.0)
     rack (2.0.7)
+    rack-pjax (1.1.0)
+      nokogiri (~> 1.5)
+      rack (>= 1.1)
     rack-protection (2.0.7)
       rack
     rack-test (1.1.0)
@@ -285,6 +299,18 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.2.0)
       loofah (~> 2.2, >= 2.2.2)
+    rails_admin (2.0.0)
+      activemodel-serializers-xml (>= 1.0)
+      builder (~> 3.1)
+      haml (>= 4.0, < 6)
+      jquery-rails (>= 3.0, < 5)
+      jquery-ui-rails (>= 5.0, < 7)
+      kaminari (>= 0.14, < 2.0)
+      nested_form (~> 0.3)
+      rack-pjax (>= 0.7)
+      rails (>= 5.0, < 7)
+      remotipart (~> 1.3)
+      sassc-rails (>= 1.3, < 3)
     railties (6.0.0)
       actionpack (= 6.0.0)
       activesupport (= 6.0.0)
@@ -298,6 +324,7 @@ GEM
       ffi (~> 1.0)
     redcarpet (3.5.0)
     redis (4.1.2)
+    remotipart (1.4.3)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -386,6 +413,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.1)
+    temple (0.8.1)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
     thor (0.20.3)
@@ -425,6 +453,7 @@ PLATFORMS
 DEPENDENCIES
   bugsnag
   byebug
+  cancancan
   climate_control
   coffee-rails (~> 5.0)
   config
@@ -453,6 +482,7 @@ DEPENDENCIES
   pry
   puma (~> 4.1)
   rails (~> 6.0)
+  rails_admin
   redcarpet
   rinku
   rspec-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,9 @@ GEM
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
+    paper_trail (10.3.1)
+      activerecord (>= 4.2)
+      request_store (~> 1.1)
     parallel (1.17.0)
     parser (2.6.4.0)
       ast (~> 2.4.0)
@@ -325,6 +328,8 @@ GEM
     redcarpet (3.5.0)
     redis (4.1.2)
     remotipart (1.4.3)
+    request_store (1.4.1)
+      rack (>= 1.4)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -478,6 +483,7 @@ DEPENDENCIES
   octokit (~> 4.14)
   omniauth-github
   omniauth-rails_csrf_protection (~> 0.1)
+  paper_trail
   pg
   pry
   puma (~> 4.1)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+#
+# Admin capability configuration for CanCanCan
+#
+class Ability
+  include CanCan::Ability
+  def initialize(user)
+    return unless user && user.admin?
+    can :access, :rails_admin
+    can :manage, :all
+  end
+end

--- a/app/models/concerns/user_admin.rb
+++ b/app/models/concerns/user_admin.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+#
+# Configuration for user admin interface
+#
+module UserAdmin
+  extend ActiveSupport::Concern
+
+  included do
+    rails_admin do
+      object_label_method do
+        :login
+      end
+      list do
+        field :avatar do
+          pretty_value do
+            bindings[:view].tag(:img, src: bindings[:object].avatar_url, height: "20px")
+          end
+        end
+        field :login
+        field :role
+        field :author
+        field :voter
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@
 #
 class User < ApplicationRecord
   include UserAdmin
+  has_paper_trail
 
   default_scope { order(:login) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@
 # Generic humanoid carbon unit
 #
 class User < ApplicationRecord
+  include UserAdmin
+
   default_scope { order(:login) }
 
   devise :omniauthable, omniauth_providers: [:github]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,6 +34,7 @@
               <li><%= link_to "Proposals", proposals_path %></li>
               <li><%= link_to "Ideas", ideas_path %></li>
               <li><%= link_to "People", users_path %></li>
+              <% if can? :access, :rails_admin %><li><%= link_to "Admin", rails_admin_path %></li><% end %>
             </ul>
             <ul class="nav navbar-nav navbar-right">
               <% if signed_in? %>

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -10,7 +10,7 @@ RailsAdmin.config do |config|
   config.authorize_with :cancancan
 
   # == PaperTrail ==
-  # config.audit_with :paper_trail, 'User', 'PaperTrail::Version' # PaperTrail >= 3.0.0
+  config.audit_with :paper_trail, 'User', 'PaperTrail::Version'
 
   config.included_models = [ User, Proposal ]
 
@@ -21,8 +21,8 @@ RailsAdmin.config do |config|
     show_in_app
     delete
 
-    ## With an audit adapter, you can add:
-    # history_index
-    # history_show
+    # PaperTrail
+    history_index
+    history_show
   end
 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -12,6 +12,7 @@ RailsAdmin.config do |config|
   # == PaperTrail ==
   # config.audit_with :paper_trail, 'User', 'PaperTrail::Version' # PaperTrail >= 3.0.0
 
+  config.included_models = [ User, Proposal ]
   config.actions do
     dashboard
     index

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,0 +1,26 @@
+RailsAdmin.config do |config|
+
+  # == Devise ==
+  config.authenticate_with do
+    warden.authenticate! scope: :user
+  end
+  config.current_user_method(&:current_user)
+
+  # == CancanCan ==
+  config.authorize_with :cancancan
+
+  # == PaperTrail ==
+  # config.audit_with :paper_trail, 'User', 'PaperTrail::Version' # PaperTrail >= 3.0.0
+
+  config.actions do
+    dashboard
+    index
+    show
+    edit
+    show_in_app
+
+    ## With an audit adapter, you can add:
+    # history_index
+    # history_show
+  end
+end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -13,12 +13,13 @@ RailsAdmin.config do |config|
   # config.audit_with :paper_trail, 'User', 'PaperTrail::Version' # PaperTrail >= 3.0.0
 
   config.included_models = [ User, Proposal ]
+
   config.actions do
     dashboard
     index
-    show
     edit
     show_in_app
+    delete
 
     ## With an audit adapter, you can add:
     # history_index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   resources :users
 
   # Login

--- a/db/migrate/20190909205827_create_versions.rb
+++ b/db/migrate/20190909205827_create_versions.rb
@@ -1,0 +1,36 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[6.0]
+
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions do |t|
+      t.string   :item_type, {:null=>false}
+      t.integer  :item_id,   null: false, limit: 8
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.text     :object, limit: TEXT_BYTES
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      t.datetime :created_at
+    end
+    add_index :versions, %i(item_type item_id)
+  end
+end

--- a/db/migrate/20190909205828_add_object_changes_to_versions.rb
+++ b/db/migrate/20190909205828_add_object_changes_to_versions.rb
@@ -1,0 +1,12 @@
+# This migration adds the optional `object_changes` column, in which PaperTrail
+# will store the `changes` diff for each update event. See the readme for
+# details.
+class AddObjectChangesToVersions < ActiveRecord::Migration[6.0]
+  # The largest text column available in all supported RDBMS.
+  # See `create_versions.rb` for details.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    add_column :versions, :object_changes, :text, limit: TEXT_BYTES
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_08_215603) do
+ActiveRecord::Schema.define(version: 2019_09_09_205828) do
 
   create_table "interactions", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -45,6 +45,17 @@ ActiveRecord::Schema.define(version: 2019_09_08_215603) do
     t.boolean "notify_new", default: true
     t.boolean "voter", default: false, null: false
     t.integer "role"
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.integer "item_id", limit: 8, null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "object", limit: 1073741823
+    t.datetime "created_at"
+    t.text "object_changes", limit: 1073741823
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
 end


### PR DESCRIPTION
Adds an admin interface for users with the `admin` role set. Includes audit log tracking for users to track things like people being given (or losing) the vote, becoming authors, etc.