### PR TITLE
Configure redis connection pool sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ spec/examples.txt
 .yardoc
 doc
 .vscode
+dump.rdb

--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,6 @@ group :development, :test do
   gem "rubocop-performance", require: false
   gem "yard"
   gem "climate_control"
-  gem "foreman"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ group :development, :test do
   gem "rubocop-performance", require: false
   gem "yard"
   gem "climate_control"
+  gem "foreman"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,8 +149,8 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
     font-awesome-rails (4.7.0.5)
-      railties (>= 3.2, < 6.1)
       dotenv (>= 0.7)
+      railties (>= 3.2, < 6.1)
     formatador (0.2.5)
     github-markup (3.0.4)
     globalid (0.4.2)
@@ -470,7 +470,6 @@ DEPENDENCIES
   factory_bot_rails
   faker
   font-awesome-rails
-  foreman
   github-markup
   guard
   guard-rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,7 @@ GEM
     ffi (1.11.1)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
+      dotenv (>= 0.7)
     formatador (0.2.5)
     github-markup (3.0.4)
     globalid (0.4.2)
@@ -469,6 +470,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   font-awesome-rails
+  foreman
   github-markup
   guard
   guard-rspec

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec bin/rails server -p $PORT -e $RAILS_ENV
-worker: bundle exec sidekiq -q default -q mailers -c 10
+worker: bundle exec sidekiq -q default -q mailers

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,8 @@
+Sidekiq.configure_client do |config|
+  config.redis = { size: 5, url: ENV["REDIS_URL"] }
+end
+
+Sidekiq.configure_server do |config|
+  config.redis = { concurrency: 5, url: ENV["REDIS_URL"] }
+end
+

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,8 +1,3 @@
 Sidekiq.configure_client do |config|
   config.redis = { size: 5, url: ENV["REDIS_URL"] }
 end
-
-Sidekiq.configure_server do |config|
-  config.redis = { concurrency: 5, url: ENV["REDIS_URL"] }
-end
-

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,8 +4,8 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+max_threads_count = Integer(ENV.fetch("RAILS_MAX_THREADS") { 5 })
+min_threads_count = Integer(ENV.fetch("RAILS_MIN_THREADS") { max_threads_count })
 threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
@@ -25,7 +25,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers Integer(ENV.fetch("WEB_CONCURRENCY") { 2 })
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
+require 'sidekiq/web'
 
 Rails.application.routes.draw do
-  mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
+  authenticate :user, lambda { |u| u.admin? } do
+    mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
+    mount Sidekiq::Web => '/sidekiq'
+  end
+
   resources :users
 
   # Login

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,2 @@
+---
+:concurrency: 8


### PR DESCRIPTION
So they can't go over the Redis hobby-dev limit on Heroku, which is 20 connections total. This allows 5 for the workers, 2 for sidekiq itself, plus 5 for each puma worker (of which there are 2 by default). That's a total of 17, which it should never exceed.

Resolves #465