### PR TITLE
Set PR labels

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,9 @@ RSpec:
 Layout/ClassStructure:
   Enabled: true
 
+Layout/LineLength:
+  Max: 100
+
 Metrics:
   Enabled: true
 
@@ -40,9 +43,6 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*.rb'
     - 'Guardfile'
-
-Metrics/LineLength:
-  Max: 100
 
 Performance/CaseWhenSplat:
   Enabled: true

--- a/app/controllers/edit_controller.rb
+++ b/app/controllers/edit_controller.rb
@@ -166,7 +166,7 @@ class EditController < ApplicationController
     def open_pr(head, base, title, description)
       pr = github.create_pull_request(
         original_repo_path, base, head, title, description,
-        labels: ["groupthink::proposal"]
+        labels: [PROPOSAL_LABEL]
       )
       Proposal.find_or_create_by!(
         number: pr.number,

--- a/app/controllers/edit_controller.rb
+++ b/app/controllers/edit_controller.rb
@@ -164,16 +164,15 @@ class EditController < ApplicationController
     end
 
     def open_pr(head, base, title, description)
-      pr = github.create_pull_request(
-        original_repo_path, base, head, title, description,
-        labels: [PROPOSAL_LABEL]
-      )
+      pr = github.create_pull_request(original_repo_path, base, head, title, description)
       Proposal.find_or_create_by!(
         number: pr.number,
         opened_at: Time.zone.now,
         title: title,
         proposer: @current_user
       )
+      # Set PR label directly using admin as other users might not be able to
+      Octokit.add_issue_labels(original_repo_path, pr.number, [PROPOSAL_LABEL])
     end
 
     def commit_file(repo, name, content, message, base_sha, branch_name)

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -5,7 +5,7 @@
 #
 class IdeasController < ApplicationController
   def index
-    @ideas = Octokit.issues(ENV.fetch("GITHUB_REPO"), labels: "groupthink::idea")
+    @ideas = Octokit.issues(ENV.fetch("GITHUB_REPO"), labels: IDEA_LABEL)
   end
 
   def show

--- a/app/views/ideas/index.html.erb
+++ b/app/views/ideas/index.html.erb
@@ -1,5 +1,5 @@
 <div class='pull-right'>
-  <a href='https://github.com/<%= ENV.fetch("GITHUB_REPO") %>/issues/new?labels=groupthink::idea' class='btn btn-primary' style='margin: 25px 0px'>
+  <a href='https://github.com/<%= ENV.fetch("GITHUB_REPO") %>/issues/new?labels=<%= IDEA_LABEL %>' class='btn btn-primary' style='margin: 25px 0px'>
     <%= fa_icon 'plus' %>
     Suggest a new idea
   </a>

--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -13,6 +13,9 @@ rescue Octokit::NotFound
   Octokit.add_label(ENV.fetch("GITHUB_REPO"), label, colour, description: description)
 end
 
+IDEA_LABEL = "groupthink::idea"
+PROPOSAL_LABEL = "groupthink::proposal"
+
 unless Rails.env.test?
   # Configure GitHub webhook automatically
   begin
@@ -44,6 +47,6 @@ unless Rails.env.test?
   }
   Octokit.edit_repository(ENV.fetch("GITHUB_REPO"), repo_options)
   # Set up labels
-  create_label_if_missing(label: "groupthink::proposal", colour: "d4c5f9", description: "Proposals to be voted on in Groupthink")
-  create_label_if_missing(label: "groupthink::idea", colour: "fbca04", description: "Ideas for future proposals")
+  create_label_if_missing(label: PROPOSAL_LABEL, colour: "d4c5f9", description: "Proposals to be voted on in Groupthink")
+  create_label_if_missing(label: IDEA_LABEL, colour: "fbca04", description: "Ideas for future proposals")
 end


### PR DESCRIPTION
Labels can only be set by users with push permissions, so we do this as a separate task using the admin token instead of the user's token.